### PR TITLE
feat: Add always-on validation with custom LLM exception hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **Always-on field validation**: Automatic validation of all LLM responses against schema definitions
-- **Custom exception hierarchy**: Specific exceptions for different validation failures to enable retry logic
-  - `Structify::LLMValidationError` - Base exception for all validation errors
-  - `Structify::TypeMismatchError` - When LLM returns wrong data type (e.g., string instead of array)
-  - `Structify::RequiredFieldError` - When required fields are missing
-  - `Structify::EnumValidationError` - When values don't match allowed enum options
-  - `Structify::ArrayConstraintError` - When array constraints are violated (min_items, max_items, unique_items)
-  - `Structify::ObjectValidationError` - When object property validation fails
-- **Comprehensive validation support**: 
-  - Type validation for all field types (string, integer, array, object, etc.)
-  - Required field validation
-  - Enum value validation
-  - Array constraint validation (min_items, max_items, unique_items)
-  - Nested object property validation
-  - Array item validation including complex objects
+- **Always-on validation**: Automatic validation of all LLM responses against schema definitions
+- **Custom exceptions for retry logic**: `TypeMismatchError`, `RequiredFieldError`, `EnumValidationError`, `ArrayConstraintError`, `ObjectValidationError`
 
 ### Changed
 
-- **Breaking**: Validation is now always enabled and cannot be disabled
-- Field validation errors now raise exceptions instead of adding ActiveRecord errors for better LLM retry handling
+- **Breaking**: Validation is now always enabled and raises exceptions instead of ActiveRecord errors
 
 ## [0.3.4] - 2025-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Always-on field validation**: Automatic validation of all LLM responses against schema definitions
+- **Custom exception hierarchy**: Specific exceptions for different validation failures to enable retry logic
+  - `Structify::LLMValidationError` - Base exception for all validation errors
+  - `Structify::TypeMismatchError` - When LLM returns wrong data type (e.g., string instead of array)
+  - `Structify::RequiredFieldError` - When required fields are missing
+  - `Structify::EnumValidationError` - When values don't match allowed enum options
+  - `Structify::ArrayConstraintError` - When array constraints are violated (min_items, max_items, unique_items)
+  - `Structify::ObjectValidationError` - When object property validation fails
+- **Comprehensive validation support**: 
+  - Type validation for all field types (string, integer, array, object, etc.)
+  - Required field validation
+  - Enum value validation
+  - Array constraint validation (min_items, max_items, unique_items)
+  - Nested object property validation
+  - Array item validation including complex objects
+
+### Changed
+
+- **Breaking**: Validation is now always enabled and cannot be disabled
+- Field validation errors now raise exceptions instead of adding ActiveRecord errors for better LLM retry handling
+
 ## [0.3.4] - 2025-03-19
 
 ### Changed

--- a/lib/structify.rb
+++ b/lib/structify.rb
@@ -2,6 +2,7 @@
 
 require_relative "structify/version"
 require_relative "structify/schema_serializer"
+require_relative "structify/field_validation"
 require_relative "structify/model"
 
 # Structify is a DSL for defining extraction schemas for LLM-powered models.
@@ -28,8 +29,16 @@ module Structify
     # @return [Symbol] The default container attribute for JSON fields
     attr_accessor :default_container_attribute
     
+    # @return [Boolean] Whether to validate data against schema on save
+    attr_accessor :validate_on_save
+    
+    # @return [Boolean] Whether to raise exceptions on validation failure instead of adding errors
+    attr_accessor :strict_validation
+    
     def initialize
       @default_container_attribute = :json_attributes
+      @validate_on_save = true  # Enable validation by default
+      @strict_validation = false  # Add errors instead of raising by default
     end
   end
   
@@ -110,6 +119,69 @@ module Structify
       else
         "#{versions} and above"  # Single integer means this version and onwards
       end
+    end
+  end
+
+  # Base exception for all validation errors from LLM responses
+  class LLMValidationError < Error
+    attr_reader :field_name, :value, :record
+    
+    def initialize(field_name, value, message, record: nil)
+      @field_name = field_name
+      @value = value
+      @record = record
+      super(message)
+    end
+  end
+  
+  # Error raised when LLM returns wrong data type
+  class TypeMismatchError < LLMValidationError
+    attr_reader :expected_type, :actual_type
+    
+    def initialize(field_name, value, expected_type, actual_type, record: nil)
+      @expected_type = expected_type
+      @actual_type = actual_type
+      
+      message = "Field '#{field_name}' expected #{expected_type}, got #{actual_type}: #{value.inspect}"
+      super(field_name, value, message, record: record)
+    end
+  end
+  
+  # Error raised when required field is missing
+  class RequiredFieldError < LLMValidationError
+    def initialize(field_name, record: nil)
+      message = "Required field '#{field_name}' is missing or nil"
+      super(field_name, nil, message, record: record)
+    end
+  end
+  
+  # Error raised when enum value is invalid
+  class EnumValidationError < LLMValidationError
+    attr_reader :allowed_values
+    
+    def initialize(field_name, value, allowed_values, record: nil)
+      @allowed_values = allowed_values
+      message = "Field '#{field_name}' value #{value.inspect} is not in allowed values: #{allowed_values.inspect}"
+      super(field_name, value, message, record: record)
+    end
+  end
+  
+  # Error raised when array constraints are violated
+  class ArrayConstraintError < LLMValidationError
+    def initialize(field_name, value, constraint_message, record: nil)
+      message = "Field '#{field_name}' array constraint violation: #{constraint_message}"
+      super(field_name, value, message, record: record)
+    end
+  end
+  
+  # Error raised when object property validation fails
+  class ObjectValidationError < LLMValidationError
+    attr_reader :property_name
+    
+    def initialize(field_name, value, property_name, property_message, record: nil)
+      @property_name = property_name
+      message = "Field '#{field_name}' object validation failed for property '#{property_name}': #{property_message}"
+      super(field_name, value, message, record: record)
     end
   end
 end

--- a/lib/structify.rb
+++ b/lib/structify.rb
@@ -29,16 +29,8 @@ module Structify
     # @return [Symbol] The default container attribute for JSON fields
     attr_accessor :default_container_attribute
     
-    # @return [Boolean] Whether to validate data against schema on save
-    attr_accessor :validate_on_save
-    
-    # @return [Boolean] Whether to raise exceptions on validation failure instead of adding errors
-    attr_accessor :strict_validation
-    
     def initialize
       @default_container_attribute = :json_attributes
-      @validate_on_save = true  # Enable validation by default
-      @strict_validation = false  # Add errors instead of raising by default
     end
   end
   

--- a/lib/structify/field_validation.rb
+++ b/lib/structify/field_validation.rb
@@ -1,0 +1,447 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Structify
+  # Module that provides always-on validation for Structify fields against the defined schema.
+  # 
+  # This module is automatically included in models that use Structify::Model and validates
+  # all LLM responses to ensure they conform to the schema definition. It raises specific
+  # exceptions for different validation failures to enable retry logic.
+  #
+  # @example Basic usage with validation errors
+  #   class Article < ApplicationRecord
+  #     include Structify::Model
+  #
+  #     schema_definition do
+  #       field :title, :string, required: true
+  #       field :category, :string, enum: ["tech", "business", "science"]
+  #       field :tags, :array, items: { type: "string" }, min_items: 1
+  #     end
+  #   end
+  #
+  #   # These will raise validation errors:
+  #   article = Article.new
+  #   article.title = 123  # TypeMismatchError: expected string, got integer
+  #   article.category = "invalid"  # EnumValidationError: not in allowed values
+  #   article.tags = []  # ArrayConstraintError: must have at least 1 items
+  #
+  # @example Handling validation errors for LLM retries
+  #   begin
+  #     article.update!(llm_response)
+  #   rescue Structify::TypeMismatchError => e
+  #     Rails.logger.warn "Type mismatch for #{e.field_name}: #{e.message}"
+  #     retry_with_better_prompt(e.field_name, e.expected_type)
+  #   rescue Structify::RequiredFieldError => e
+  #     Rails.logger.warn "Missing required field: #{e.message}"
+  #     retry_with_explicit_requirement(e.field_name)
+  #   end
+  #
+  # @example Complex object validation
+  #   schema_definition do
+  #     field :author, :object, required: true, properties: {
+  #       "name" => { type: "string", required: true },
+  #       "email" => { type: "string" }
+  #     }
+  #     field :activities, :array, items: {
+  #       type: "object",
+  #       properties: {
+  #         "title" => { type: "string", required: true },
+  #         "impact" => { type: "integer", required: true }
+  #       }
+  #     }
+  #   end
+  #
+  #   # Invalid: missing required object property
+  #   article.author = { email: "test@example.com" }  # ObjectValidationError: missing required property 'name'
+  #   
+  #   # Invalid: array item missing required property
+  #   article.activities = [{ title: "Test" }]  # ArrayConstraintError: missing required property 'impact'
+  #
+  # @see Structify::LLMValidationError Base class for all validation errors
+  # @see Structify::TypeMismatchError For type validation failures
+  # @see Structify::RequiredFieldError For missing required fields
+  # @see Structify::EnumValidationError For invalid enum values
+  # @see Structify::ArrayConstraintError For array validation failures
+  # @see Structify::ObjectValidationError For object property validation failures
+  module FieldValidation
+    extend ActiveSupport::Concern
+    
+    included do
+      validate :validate_structify_fields
+    end
+    
+    private
+    
+    # Main validation method that validates all fields defined in the schema.
+    # Called automatically by ActiveRecord during validation lifecycle.
+    #
+    # @return [void]
+    # @raise [Structify::LLMValidationError] When any field validation fails
+    def validate_structify_fields
+      return unless self.class.schema_builder
+      
+      self.class.schema_builder.fields.each do |field_def|
+        validate_field(field_def)
+      end
+    end
+    
+    # Validate a single field against its definition.
+    #
+    # @param field_def [Hash] The field definition from schema_builder
+    # @option field_def [Symbol] :name The field name
+    # @option field_def [Symbol] :type The expected type (:string, :integer, :array, etc.)
+    # @option field_def [Boolean] :required Whether the field is required
+    # @option field_def [Array] :enum Allowed enum values
+    # @option field_def [Hash] :items Schema for array items
+    # @option field_def [Hash] :properties Schema for object properties
+    # @return [void]
+    # @raise [Structify::LLMValidationError] When validation fails
+    def validate_field(field_def)
+      field_name = field_def[:name]
+      
+      # Skip if field not accessible in current version
+      return unless version_field_accessible?(field_def)
+      
+      begin
+        value = read_field_value(field_name)
+      rescue VersionRangeError, RemovedFieldError
+        # Field is not accessible in this version, skip validation
+        return
+      end
+      
+      # Required field validation
+      validate_required_field(field_name, value, field_def[:required])
+      
+      return if value.nil?
+      
+      # Type validation
+      validate_field_type(field_name, value, field_def[:type])
+      
+      # Enum validation
+      validate_enum_field(field_name, value, field_def[:enum]) if field_def[:enum]
+      
+      # Array constraints
+      validate_array_constraints(field_name, value, field_def) if field_def[:type] == :array
+      
+      # Object validation
+      validate_object_properties(field_name, value, field_def) if field_def[:type] == :object
+    end
+    
+    # Check if a field is accessible in the current record's version
+    def version_field_accessible?(field_def)
+      return true unless field_def[:version_range]
+      
+      record_version = stored_version
+      version_in_range?(record_version, field_def[:version_range])
+    end
+    
+    # Safely read a field value, handling version errors
+    def read_field_value(field_name)
+      send(field_name)
+    rescue NoMethodError
+      # Field accessor doesn't exist, return nil
+      nil
+    end
+    
+    # Validate that required fields are present.
+    #
+    # @param field_name [Symbol] The name of the field being validated
+    # @param value [Object] The field value
+    # @param required [Boolean] Whether the field is required
+    # @return [void]
+    # @raise [Structify::RequiredFieldError] When required field is missing
+    def validate_required_field(field_name, value, required)
+      if required && (value.nil? || (value.respond_to?(:empty?) && value.empty?))
+        raise RequiredFieldError.new(field_name, record: self)
+      end
+    end
+    
+    # Validate field type matches expected type.
+    #
+    # @param field_name [Symbol] The name of the field being validated
+    # @param value [Object] The field value
+    # @param expected_type [Symbol] Expected type (:string, :integer, :array, etc.)
+    # @return [void]
+    # @raise [Structify::TypeMismatchError] When value type doesn't match expected type
+    def validate_field_type(field_name, value, expected_type)
+      valid = case expected_type
+              when :string, :text
+                value.is_a?(String)
+              when :integer
+                value.is_a?(Integer)
+              when :number
+                value.is_a?(Numeric)
+              when :boolean
+                value.is_a?(TrueClass) || value.is_a?(FalseClass)
+              when :array
+                value.is_a?(Array)
+              when :object
+                value.is_a?(Hash)
+              else
+                true
+              end
+      
+      unless valid
+        actual_type = value.class.name.downcase
+        actual_type = "boolean" if [TrueClass, FalseClass].include?(value.class)
+        
+        raise TypeMismatchError.new(
+          field_name,
+          value,
+          expected_type,
+          actual_type,
+          record: self
+        )
+      end
+    end
+    
+    # Validate enum field values
+    def validate_enum_field(field_name, value, allowed_values)
+      # Allow nil for optional enum fields
+      return if value.nil?
+      
+      unless allowed_values.include?(value)
+        raise EnumValidationError.new(
+          field_name,
+          value,
+          allowed_values,
+          record: self
+        )
+      end
+    end
+    
+    # Validate array constraints (min_items, max_items, unique_items)
+    def validate_array_constraints(field_name, array, field_def)
+      return unless array.is_a?(Array)
+      
+      min_items = field_def[:min_items]
+      max_items = field_def[:max_items]
+      unique_items = field_def[:unique_items]
+      items_schema = field_def[:items]
+      
+      # Validate min_items
+      if min_items && array.length < min_items
+        raise ArrayConstraintError.new(
+          field_name,
+          array,
+          "must have at least #{min_items} items, got #{array.length}",
+          record: self
+        )
+      end
+      
+      # Validate max_items
+      if max_items && array.length > max_items
+        raise ArrayConstraintError.new(
+          field_name,
+          array,
+          "must have at most #{max_items} items, got #{array.length}",
+          record: self
+        )
+      end
+      
+      # Validate unique_items
+      if unique_items && array.uniq.length != array.length
+        raise ArrayConstraintError.new(
+          field_name,
+          array,
+          "items must be unique",
+          record: self
+        )
+      end
+      
+      # Validate items schema
+      if items_schema
+        validate_array_items(field_name, array, items_schema)
+      end
+    end
+    
+    # Validate individual array items against schema
+    def validate_array_items(field_name, array, items_schema)
+      array.each_with_index do |item, index|
+        # Type validation for array items
+        if items_schema[:type] || items_schema["type"]
+          item_type = items_schema[:type] || items_schema["type"]
+          validate_array_item_type(field_name, item, item_type, index)
+        end
+        
+        # Enum validation for array items
+        if items_schema[:enum] || items_schema["enum"]
+          item_enum = items_schema[:enum] || items_schema["enum"]
+          validate_array_item_enum(field_name, item, item_enum, index)
+        end
+        
+        # Object validation for array items
+        if item_type == "object" && (items_schema[:properties] || items_schema["properties"])
+          item_properties = items_schema[:properties] || items_schema["properties"]
+          validate_array_item_object(field_name, item, item_properties, index)
+        end
+      end
+    end
+    
+    # Validate array item type
+    def validate_array_item_type(field_name, item, expected_type, index)
+      expected_type = expected_type.to_s if expected_type.is_a?(Symbol)
+      
+      valid = case expected_type
+              when "string"
+                item.is_a?(String)
+              when "integer"
+                item.is_a?(Integer)
+              when "number"
+                item.is_a?(Numeric)
+              when "boolean"
+                item.is_a?(TrueClass) || item.is_a?(FalseClass)
+              when "object"
+                item.is_a?(Hash)
+              when "array"
+                item.is_a?(Array)
+              else
+                true
+              end
+      
+      unless valid
+        actual_type = item.class.name.downcase
+        actual_type = "boolean" if [TrueClass, FalseClass].include?(item.class)
+        
+        raise ArrayConstraintError.new(
+          field_name,
+          item,
+          "item at index #{index} expected #{expected_type}, got #{actual_type}: #{item.inspect}",
+          record: self
+        )
+      end
+    end
+    
+    # Validate array item enum values
+    def validate_array_item_enum(field_name, item, allowed_values, index)
+      unless allowed_values.include?(item)
+        raise ArrayConstraintError.new(
+          field_name,
+          item,
+          "item at index #{index} value #{item.inspect} is not in allowed values: #{allowed_values.inspect}",
+          record: self
+        )
+      end
+    end
+    
+    # Validate array item object properties
+    def validate_array_item_object(field_name, item, properties_schema, index)
+      return unless item.is_a?(Hash)
+      
+      properties_schema.each do |prop_name, prop_schema|
+        prop_value = item[prop_name.to_s] || item[prop_name.to_sym]
+        
+        # Check required properties
+        if (prop_schema[:required] || prop_schema["required"]) && prop_value.nil?
+          raise ArrayConstraintError.new(
+            field_name,
+            item,
+            "item at index #{index} is missing required property '#{prop_name}'",
+            record: self
+          )
+        end
+        
+        # Validate property type if present
+        if prop_value && (prop_schema[:type] || prop_schema["type"])
+          prop_type = prop_schema[:type] || prop_schema["type"]
+          validate_object_property_type(field_name, prop_name, prop_value, prop_type, "item at index #{index}")
+        end
+      end
+    end
+    
+    # Validate object properties against schema
+    def validate_object_properties(field_name, object, field_def)
+      properties_schema = field_def[:properties]
+      return unless object.is_a?(Hash) && properties_schema
+      
+      properties_schema.each do |prop_name, prop_schema|
+        prop_value = object[prop_name.to_s] || object[prop_name.to_sym]
+        
+        # Check required properties
+        if (prop_schema[:required] || prop_schema["required"]) && prop_value.nil?
+          raise ObjectValidationError.new(
+            field_name,
+            object,
+            prop_name,
+            "required property is missing",
+            record: self
+          )
+        end
+        
+        # Validate property type if present
+        if prop_value && (prop_schema[:type] || prop_schema["type"])
+          prop_type = prop_schema[:type] || prop_schema["type"]
+          validate_object_property_type(field_name, prop_name, prop_value, prop_type)
+        end
+        
+        # Validate property enum if present
+        if prop_value && (prop_schema[:enum] || prop_schema["enum"])
+          prop_enum = prop_schema[:enum] || prop_schema["enum"]
+          validate_object_property_enum(field_name, prop_name, prop_value, prop_enum)
+        end
+      end
+    end
+    
+    # Validate object property type
+    def validate_object_property_type(field_name, prop_name, prop_value, expected_type, context = nil)
+      expected_type = expected_type.to_s if expected_type.is_a?(Symbol)
+      
+      valid = case expected_type
+              when "string"
+                prop_value.is_a?(String)
+              when "integer"
+                prop_value.is_a?(Integer)
+              when "number"
+                prop_value.is_a?(Numeric)
+              when "boolean"
+                prop_value.is_a?(TrueClass) || prop_value.is_a?(FalseClass)
+              when "object"
+                prop_value.is_a?(Hash)
+              when "array"
+                prop_value.is_a?(Array)
+              else
+                true
+              end
+      
+      unless valid
+        actual_type = prop_value.class.name.downcase
+        actual_type = "boolean" if [TrueClass, FalseClass].include?(prop_value.class)
+        
+        property_message = "property '#{prop_name}' expected #{expected_type}, got #{actual_type}: #{prop_value.inspect}"
+        property_message = "#{context} #{property_message}" if context
+        
+        if context
+          # This is from an array item validation
+          raise ArrayConstraintError.new(
+            field_name,
+            prop_value,
+            property_message,
+            record: self
+          )
+        else
+          raise ObjectValidationError.new(
+            field_name,
+            prop_value,
+            prop_name,
+            "expected #{expected_type}, got #{actual_type}: #{prop_value.inspect}",
+            record: self
+          )
+        end
+      end
+    end
+    
+    # Validate object property enum values
+    def validate_object_property_enum(field_name, prop_name, prop_value, allowed_values)
+      unless allowed_values.include?(prop_value)
+        raise ObjectValidationError.new(
+          field_name,
+          prop_value,
+          prop_name,
+          "value #{prop_value.inspect} is not in allowed values: #{allowed_values.inspect}",
+          record: self
+        )
+      end
+    end
+  end
+end

--- a/lib/structify/model.rb
+++ b/lib/structify/model.rb
@@ -4,8 +4,6 @@ require "active_support/concern"
 require "active_support/core_ext/class/attribute"
 require "attr_json"
 require_relative "schema_serializer"
-require_relative "field_validations"
-require_relative "types/validated_array"
 
 module Structify
   # The Model module provides a DSL for defining LLM extraction schemas in your Rails models.
@@ -33,7 +31,6 @@ module Structify
       include Structify::FieldValidation
       
       class_attribute :schema_builder, instance_writer: false, default: nil
-      class_attribute :skip_validation, instance_writer: false, default: false
 
       # Use the configured default container attribute
       attr_json_config(default_container_attribute: Structify.configuration.default_container_attribute)
@@ -301,8 +298,7 @@ module Structify
         validations: validations
       }.compact
       
-      # Apply validations to the model
-      FieldValidations.apply_field_validations(model, name, field_config)
+      # Note: Field validations are handled automatically by the FieldValidation module
     end
     
     # Check if a version is within a given range/array of versions

--- a/lib/structify/model.rb
+++ b/lib/structify/model.rb
@@ -4,6 +4,8 @@ require "active_support/concern"
 require "active_support/core_ext/class/attribute"
 require "attr_json"
 require_relative "schema_serializer"
+require_relative "field_validations"
+require_relative "types/validated_array"
 
 module Structify
   # The Model module provides a DSL for defining LLM extraction schemas in your Rails models.
@@ -28,7 +30,10 @@ module Structify
 
     included do
       include AttrJson::Record
+      include Structify::FieldValidation
+      
       class_attribute :schema_builder, instance_writer: false, default: nil
+      class_attribute :skip_validation, instance_writer: false, default: false
 
       # Use the configured default container attribute
       attr_json_config(default_container_attribute: Structify.configuration.default_container_attribute)
@@ -40,6 +45,19 @@ module Structify
       record_data = self.send(container_attribute) || {}
       record_version = record_data["version"] || 1
       record_version >= required_version
+    end
+    
+    # Check if field validations should be applied
+    # This respects the same configuration as JSON Schema validation
+    def should_validate_fields?
+      # Skip if validation is disabled for this class
+      return false if self.class.skip_validation
+      
+      # Skip if validation is globally disabled
+      return false unless Structify.configuration.validate_on_save
+      
+      # Otherwise, validate fields
+      true
     end
     
     # Get the stored version of this record
@@ -185,10 +203,11 @@ module Structify
     # @param max_items [Integer] For array type, maximum number of items
     # @param unique_items [Boolean] For array type, whether items must be unique
     # @param versions [Range, Array, Integer] The versions this field is available in (default: current version onwards)
+    # @param validations [Hash] Additional validations to apply (e.g., { format: /\A\d+\z/, length: { minimum: 3 } })
     # @return [void]
     def field(name, type, required: false, description: nil, enum: nil, 
               items: nil, properties: nil, min_items: nil, max_items: nil, 
-              unique_items: nil, versions: nil)
+              unique_items: nil, versions: nil, validations: nil)
       
       # Handle version information
       version_range = if versions
@@ -267,6 +286,23 @@ module Structify
 
       # Define custom accessor that checks version compatibility
       define_version_range_accessors(name, attr_type, version_range)
+      
+      # Define setter interceptor to capture raw values for validation
+      define_validation_interceptor(name)
+      
+      # Apply field validations using attr_json and ActiveRecord validations
+      field_config = {
+        type: type,
+        required: required,
+        enum: enum,
+        min_items: min_items,
+        max_items: max_items,
+        unique_items: unique_items,
+        validations: validations
+      }.compact
+      
+      # Apply validations to the model
+      FieldValidations.apply_field_validations(model, name, field_config)
     end
     
     # Check if a version is within a given range/array of versions
@@ -360,6 +396,40 @@ module Structify
           
           # Call original method
           _original_#{name}
+        end
+      RUBY
+    end
+    
+    # Define setter interceptor to capture raw values for validation
+    #
+    # @param name [Symbol] The field name
+    # @return [void]
+    def define_validation_interceptor(name)
+      model.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        # Store original setter if exists
+        if method_defined?(:#{name}=)
+          alias_method :_original_setter_#{name}=, :#{name}=
+        end
+        
+        # Override setter to capture raw value
+        def #{name}=(value)
+          # Initialize raw values hash if needed
+          @_raw_field_values ||= {}
+          
+          # Store the raw value before type coercion
+          @_raw_field_values['#{name}'] = value
+          
+          # Call the original setter (or super if no original)
+          if respond_to?(:_original_setter_#{name}=)
+            send(:_original_setter_#{name}=, value)
+          else
+            super(value)
+          end
+        end
+        
+        # Accessor for raw values (used by validation)
+        def _raw_field_values
+          @_raw_field_values ||= {}
         end
       RUBY
     end

--- a/spec/structify/field_validation_spec.rb
+++ b/spec/structify/field_validation_spec.rb
@@ -1,0 +1,536 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Structify::FieldValidation do
+  # Create a test model class that includes our module
+  let(:model_class) do
+    Class.new(ActiveRecord::Base) do
+      self.table_name = "articles"
+      include Structify::Model
+    end
+  end
+
+  # Set up our test database
+  before(:all) do
+    ActiveRecord::Schema.define do
+      create_table :articles, force: true do |t|
+        t.string :title
+        t.text :content
+        t.json :json_attributes
+        t.timestamps
+      end
+    end
+  end
+
+  describe "always-on validation" do
+    context "with basic field types" do
+      before do
+        model_class.schema_definition do
+          name "BasicValidation"
+          version 1
+          
+          field :title, :string, required: true
+          field :count, :integer
+          field :price, :number
+          field :active, :boolean
+          field :category, :string, enum: ["tech", "business", "science"]
+        end
+      end
+
+      describe "required field validation" do
+        it "raises RequiredFieldError when required field is missing" do
+          instance = model_class.new
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::RequiredFieldError) do |error|
+            expect(error.field_name).to eq(:title)
+            expect(error.message).to include("Required field 'title' is missing")
+          end
+        end
+
+        it "raises RequiredFieldError when required field is nil" do
+          instance = model_class.new(title: nil)
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::RequiredFieldError) do |error|
+            expect(error.field_name).to eq(:title)
+          end
+        end
+
+        it "raises RequiredFieldError when required field is empty string" do
+          instance = model_class.new(title: "")
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::RequiredFieldError) do |error|
+            expect(error.field_name).to eq(:title)
+          end
+        end
+
+        it "allows valid required field" do
+          instance = model_class.new(title: "Valid Title")
+          
+          expect {
+            instance.save!
+          }.not_to raise_error
+        end
+      end
+
+      describe "type validation with AttrJson coercion" do
+        it "allows AttrJson type coercion for valid coercible values" do
+          # AttrJson automatically coerces "123" to 123, "true" to true, etc.
+          instance = model_class.new(
+            title: "Valid Title",
+            count: "123",    # String that converts to integer
+            active: "true"   # String that converts to boolean
+          )
+          
+          expect {
+            instance.save!
+          }.not_to raise_error
+          
+          expect(instance.count).to eq(123)
+          expect(instance.active).to eq(true)
+        end
+
+        it "allows valid type assignments" do
+          instance = model_class.new(
+            title: "Valid Title",
+            count: 42,
+            price: 19.99,
+            active: true
+          )
+          
+          expect {
+            instance.save!
+          }.not_to raise_error
+        end
+      end
+
+      describe "enum validation" do
+        it "raises EnumValidationError for invalid enum value" do
+          instance = model_class.new(title: "Valid Title", category: "invalid")
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::EnumValidationError) do |error|
+            expect(error.field_name).to eq(:category)
+            expect(error.value).to eq("invalid")
+            expect(error.allowed_values).to eq(["tech", "business", "science"])
+          end
+        end
+
+        it "allows valid enum value" do
+          instance = model_class.new(title: "Valid Title", category: "tech")
+          
+          expect {
+            instance.save!
+          }.not_to raise_error
+        end
+
+        it "allows nil for optional enum field" do
+          instance = model_class.new(title: "Valid Title", category: nil)
+          
+          expect {
+            instance.save!
+          }.not_to raise_error
+        end
+      end
+    end
+
+    context "with array fields" do
+      before do
+        model_class.schema_definition do
+          name "ArrayValidation"
+          version 1
+          
+          field :title, :string, required: true
+          field :tags, :array, items: { type: "string" }
+          field :scores, :array, items: { type: "integer" }, min_items: 1, max_items: 5
+          field :unique_tags, :array, items: { type: "string" }, unique_items: true
+        end
+      end
+
+      describe "array type validation" do
+        it "raises TypeMismatchError when array field gets string" do
+          instance = model_class.new(title: "Valid Title", tags: "not an array")
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::TypeMismatchError) do |error|
+            expect(error.field_name).to eq(:tags)
+            expect(error.expected_type).to eq(:array)
+            expect(error.actual_type).to eq("string")
+            expect(error.value).to eq("not an array")
+          end
+        end
+
+        it "allows valid array" do
+          instance = model_class.new(title: "Valid Title", tags: ["ruby", "rails"])
+          
+          expect {
+            instance.save!
+          }.not_to raise_error
+        end
+      end
+
+      describe "array constraint validation" do
+        it "raises ArrayConstraintError for min_items violation" do
+          instance = model_class.new(title: "Valid Title", scores: [])
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::ArrayConstraintError) do |error|
+            expect(error.field_name).to eq(:scores)
+            expect(error.message).to include("must have at least 1 items")
+          end
+        end
+
+        it "raises ArrayConstraintError for max_items violation" do
+          instance = model_class.new(title: "Valid Title", scores: [1, 2, 3, 4, 5, 6])
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::ArrayConstraintError) do |error|
+            expect(error.field_name).to eq(:scores)
+            expect(error.message).to include("must have at most 5 items")
+          end
+        end
+
+        it "raises ArrayConstraintError for unique_items violation" do
+          instance = model_class.new(title: "Valid Title", unique_tags: ["ruby", "ruby"])
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::ArrayConstraintError) do |error|
+            expect(error.field_name).to eq(:unique_tags)
+            expect(error.message).to include("items must be unique")
+          end
+        end
+
+        it "allows valid array constraints" do
+          instance = model_class.new(
+            title: "Valid Title",
+            scores: [1, 2, 3],
+            unique_tags: ["ruby", "rails", "javascript"]
+          )
+          
+          expect {
+            instance.save!
+          }.not_to raise_error
+        end
+      end
+
+      describe "array item type validation" do
+        it "raises ArrayConstraintError for invalid item type" do
+          instance = model_class.new(title: "Valid Title", tags: ["valid", 123])
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::ArrayConstraintError) do |error|
+            expect(error.field_name).to eq(:tags)
+            expect(error.message).to include("item at index 1 expected string, got integer")
+          end
+        end
+
+        it "allows valid item types" do
+          instance = model_class.new(title: "Valid Title", tags: ["ruby", "rails"])
+          
+          expect {
+            instance.save!
+          }.not_to raise_error
+        end
+      end
+    end
+
+    context "with object fields" do
+      before do
+        model_class.schema_definition do
+          name "ObjectValidation"
+          version 1
+          
+          field :title, :string, required: true
+          field :author, :object, required: true, properties: {
+            "name" => { type: "string", required: true },
+            "email" => { type: "string" },
+            "age" => { type: "integer" }
+          }
+          field :metadata, :object, properties: {
+            "category" => { type: "string", enum: ["tech", "business"] },
+            "published" => { type: "boolean" }
+          }
+        end
+      end
+
+      describe "object type validation" do
+        it "raises TypeMismatchError when object field gets string" do
+          instance = model_class.new(title: "Valid Title", author: "not an object")
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::TypeMismatchError) do |error|
+            expect(error.field_name).to eq(:author)
+            expect(error.expected_type).to eq(:object)
+            expect(error.actual_type).to eq("string")
+          end
+        end
+
+        it "allows valid object" do
+          instance = model_class.new(
+            title: "Valid Title",
+            author: { "name" => "John Doe", "email" => "john@example.com" }
+          )
+          
+          expect {
+            instance.save!
+          }.not_to raise_error
+        end
+      end
+
+      describe "object property validation" do
+        it "raises ObjectValidationError for missing required property" do
+          instance = model_class.new(
+            title: "Valid Title",
+            author: { "email" => "john@example.com" }  # Missing required "name"
+          )
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::ObjectValidationError) do |error|
+            expect(error.field_name).to eq(:author)
+            expect(error.property_name).to eq("name")
+            expect(error.message).to include("required property is missing")
+          end
+        end
+
+        it "raises ObjectValidationError for invalid property type" do
+          instance = model_class.new(
+            title: "Valid Title",
+            author: { "name" => "John Doe", "age" => "thirty" }  # Age should be integer
+          )
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::ObjectValidationError) do |error|
+            expect(error.field_name).to eq(:author)
+            expect(error.property_name).to eq("age")
+            expect(error.message).to include("expected integer, got string")
+          end
+        end
+
+        it "raises ObjectValidationError for invalid property enum" do
+          instance = model_class.new(
+            title: "Valid Title",
+            author: { "name" => "John Doe" },
+            metadata: { "category" => "sports" }  # Invalid enum value
+          )
+          
+          expect {
+            instance.save!
+          }.to raise_error(Structify::ObjectValidationError) do |error|
+            expect(error.field_name).to eq(:metadata)
+            expect(error.property_name).to eq("category")
+            expect(error.message).to include("not in allowed values")
+          end
+        end
+
+        it "allows valid object properties" do
+          instance = model_class.new(
+            title: "Valid Title",
+            author: { "name" => "John Doe", "email" => "john@example.com", "age" => 30 },
+            metadata: { "category" => "tech", "published" => true }
+          )
+          
+          expect {
+            instance.save!
+          }.not_to raise_error
+        end
+      end
+    end
+
+    context "with complex nested structures" do
+      before do
+        model_class.schema_definition do
+          name "ComplexValidation"
+          version 1
+          
+          field :title, :string, required: true
+          field :activities, :array, items: {
+            type: "object",
+            properties: {
+              "title" => { type: "string", required: true },
+              "summary" => { type: "string", required: true },
+              "impact" => { type: "integer", required: true }
+            }
+          }
+        end
+      end
+
+      it "validates the exact scenario from issue #3 - string instead of array" do
+        instance = model_class.new(title: "Valid Title", activities: "123")
+        
+        expect {
+          instance.save!
+        }.to raise_error(Structify::TypeMismatchError) do |error|
+          expect(error.field_name).to eq(:activities)
+          expect(error.expected_type).to eq(:array)
+          expect(error.actual_type).to eq("string")
+          expect(error.value).to eq("123")
+        end
+      end
+
+      it "validates the exact scenario from issue #3 - invalid object structure" do
+        instance = model_class.new(title: "Valid Title", activities: [{ bad_attr: 1 }])
+        
+        expect {
+          instance.save!
+        }.to raise_error(Structify::ArrayConstraintError) do |error|
+          expect(error.field_name).to eq(:activities)
+          expect(error.message).to include("item at index 0 is missing required property 'title'")
+        end
+      end
+
+      it "allows valid complex nested structure" do
+        instance = model_class.new(
+          title: "Valid Title",
+          activities: [
+            {
+              "title" => "Infrastructure Development",
+              "summary" => "Built new roads and bridges",
+              "impact" => 4
+            },
+            {
+              "title" => "Education Reform",
+              "summary" => "Improved school curriculum",
+              "impact" => 5
+            }
+          ]
+        )
+        
+        expect {
+          instance.save!
+        }.not_to raise_error
+      end
+
+      it "validates array item object property types" do
+        instance = model_class.new(
+          title: "Valid Title",
+          activities: [
+            {
+              "title" => "Valid Activity",
+              "summary" => "Valid summary",
+              "impact" => "not an integer"  # Invalid type
+            }
+          ]
+        )
+        
+        expect {
+          instance.save!
+        }.to raise_error(Structify::ArrayConstraintError) do |error|
+          expect(error.field_name).to eq(:activities)
+          expect(error.message).to include("item at index 0 property 'impact' expected integer, got string")
+        end
+      end
+    end
+
+    context "with version constraints" do
+      let(:v1_class) do
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "articles"
+          include Structify::Model
+
+          schema_definition do
+            version 1
+            name "VersionedValidation"
+            
+            field :title, :string, required: true
+            field :old_field, :string, versions: 1
+          end
+        end
+      end
+
+      let(:v2_class) do
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "articles"
+          include Structify::Model
+
+          schema_definition do
+            version 2
+            name "VersionedValidation"
+            
+            field :title, :string, required: true, versions: 1..999
+            field :old_field, :string, versions: 1
+            field :new_field, :string, versions: 2..999
+          end
+        end
+      end
+
+      it "validates fields available in current version" do
+        instance = v1_class.new(title: "Valid Title", old_field: "Valid")
+        
+        expect {
+          instance.save!
+        }.not_to raise_error
+      end
+
+      it "skips validation for fields not available in record version" do
+        # Create v1 record
+        v1_record = v1_class.create!(title: "Valid Title", old_field: "Valid")
+        
+        # Access with v2 schema - should not validate new_field since record is v1
+        v2_record = v2_class.find(v1_record.id)
+        
+        expect {
+          v2_record.save!
+        }.not_to raise_error
+      end
+    end
+
+    context "error attributes and context" do
+      before do
+        model_class.schema_definition do
+          name "ErrorContextValidation"
+          version 1
+          
+          field :title, :string, required: true
+          field :category, :string, enum: ["tech", "business"]
+        end
+      end
+
+      it "includes record reference in exception" do
+        instance = model_class.new
+        
+        expect {
+          instance.save!
+        }.to raise_error(Structify::RequiredFieldError) do |error|
+          expect(error.record).to eq(instance)
+        end
+      end
+
+      it "includes field name and value in exception" do
+        instance = model_class.new(title: "Valid Title", category: "invalid")
+        
+        expect {
+          instance.save!
+        }.to raise_error(Structify::EnumValidationError) do |error|
+          expect(error.field_name).to eq(:category)
+          expect(error.value).to eq("invalid")
+          expect(error.allowed_values).to eq(["tech", "business"])
+        end
+      end
+    end
+  end
+
+  describe "validation inheritance" do
+    it "includes FieldValidation module automatically" do
+      expect(model_class.included_modules).to include(Structify::FieldValidation)
+    end
+
+    it "sets up validation callback" do
+      expect(model_class._validate_callbacks.map(&:filter)).to include(:validate_structify_fields)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1 
Fixes #3 

## Summary

This PR implements always-on validation for Structify that automatically validates all LLM responses against schema definitions and raises specific exceptions for different validation failures. This enables robust error handling and intelligent retry logic for LLM hallucinations and malformed responses.

## Changes

### ✨ New Features

- **Always-on field validation**: Automatic validation of all LLM responses against schema definitions
- **Custom exception hierarchy**: Specific exceptions for different validation failures to enable retry logic:
  - `Structify::LLMValidationError` - Base exception for all validation errors
  - `Structify::TypeMismatchError` - When LLM returns wrong data type (e.g., string instead of array)
  - `Structify::RequiredFieldError` - When required fields are missing
  - `Structify::EnumValidationError` - When values don't match allowed enum options
  - `Structify::ArrayConstraintError` - When array constraints are violated (min_items, max_items, unique_items)
  - `Structify::ObjectValidationError` - When object property validation fails
- **Comprehensive validation support**: 
  - Type validation for all field types (string, integer, array, object, etc.)
  - Required field validation
  - Enum value validation
  - Array constraint validation (min_items, max_items, unique_items)
  - Nested object property validation
  - Array item validation including complex objects
- **Retry best practices**: Added simple retry patterns and examples to README
- **CI badge**: Added GitHub Actions CI badge to README

### 🔧 Technical Changes

- Created `lib/structify/field_validation.rb` with comprehensive validation logic
- Updated `lib/structify/model.rb` to include the new validation module
- Removed `json_schemer` dependency in favor of custom validation logic
- Added extensive test suite with 33 test cases covering all validation scenarios

### 💥 Breaking Changes

- **Validation is now always enabled** and cannot be disabled
- **Field validation errors now raise exceptions** instead of adding ActiveRecord errors for better LLM retry handling

## Issues Resolved

- Resolves #3: LLM responses aren't validated on insert
  - ✅ Arrays now reject non-array values (strings, objects, etc.)
  - ✅ Required object properties are enforced
  - ✅ Enum values are validated against allowed options
  - ✅ Array constraints (min_items, max_items, unique_items) are enforced

- Resolves #1: How will Hallucinations be handled?
  - ✅ Custom exceptions provide specific error context for retry logic
  - ✅ Different exception types enable intelligent retry strategies
  - ✅ Simple retry patterns documented in README

## Test Results

- ✅ **33/33** new field validation tests passing
- ✅ **35/35** existing model tests passing  
- ✅ Validates exact scenarios from issues #1 and #3

## Example Usage

### Basic Validation
```ruby
# Schema defines: field :activities, :array
# LLM returns: { activities: "some string" }
# Structify raises: TypeMismatchError - expected array, got string

# Schema: field :author, :object, properties: { "name" => { type: "string", required: true } }
# LLM returns: { author: { "bio" => "Writer" } }  # Missing required "name"
# Structify raises: ObjectValidationError - missing required property 'name'
```

### Retry Pattern
```ruby
begin
  article.update\!(llm_response)
rescue Structify::LLMValidationError => e
  Rails.logger.warn "LLM validation failed: #{e.message}"
  
  # Retry in background job with improved prompt
  RetryExtractionJob.perform_later(article.id, original_content, e.field_name)
end
```

🤖 Generated with [Claude Code](https://claude.ai/code)